### PR TITLE
Added support for DICOM files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ COPY ["requirements.txt", "${APPROOT}"]
 WORKDIR $APPROOT
 
 ##################  ANTS INSTALLATION ##################
-RUN yum install -y cmake make git &&                \
-    cd $HOME &&                                     \
+RUN yum install -y cmake make git libstdc++-static &&   \
+    cd $HOME &&                                         \
     git clone https://github.com/ANTsX/ANTs.git &&  \
     cd ANTs &&                                      \ 
     git checkout tags/v2.2.0 &&                     \
@@ -22,13 +22,25 @@ RUN yum install -y cmake make git &&                \
     echo "End ccmake" &&                            \
     make -j 10 &&                                   \
     cp -r ~/ANTs/Scripts/. ~/ANTs/bin/ants/bin &&   \
-    rm -rf ~/ANTs &&                                \
-    yum remove -y cmake make git
+    rm -rf ~/ANTs                                
     
 
 ENV ANTSPATH=${HOME}/ANTs/bin/ants/bin/ 
 
 ENV PATH=${ANTSPATH}:$PATH
+#######################################################
+
+##################  DCM2NIIX INSTALLATION #############
+RUN cd $HOME &&                                             \
+    git clone https://github.com/rordenlab/dcm2niix.git &&  \
+    cd dcm2niix &&                                          \ 
+    git checkout tags/v1.0.20171204 &&                      \
+    mkdir build && cd build &&                              \
+    cmake ..    &&                                          \ 
+    make &&                                                 \
+    cp ./bin/dcm2niix $ANTSPATH &&                          \
+    yum remove -y cmake make git libstdc++-static &&        \
+    rm -rf ~/dcm2niix
 #######################################################
 
 RUN pip3 install -r requirements.txt

--- a/antsreg/antsreg.py
+++ b/antsreg/antsreg.py
@@ -39,27 +39,126 @@ class AntsReg(ChrisApp):
  
     def define_parameters(self):
         """
-        Define parameters here as needed.
-        Currently, no parameters are defined.
+        One parameter currently defined.
+
+        -f filename for fixed image. All other files in the input 
+        directory will be interpreted as moving images.
+
+        Define more parameters here as needed.
         """
+        self.add_argument('-f', dest='fixed', type=str, optional=False,
+                          help='The filename for the fixed image.')
 
     def run(self, options):
         """
         Execute default command. 
 
         Pre-requisites: 
-        * Input and output images in .nii.gz format.
-        * fixedImage.nii.gz and movingImage.nii.gz exist in the input directory.
-        * Two dimenstional
+        * Acceptable input file formats: .nii, .nii.gz, or folder of .dcm slices.
+        * Three dimenstional
+        * All directories are assumed to be a collection of 2D DICOM slices and treated as one volume.
         
-        Output files prefixed with output. 
+        DICOM files are converted to 3D NIFTI volume before image registration.
+        files without .dcm extension in DICOM directory are ignored.
+        Slices in single DICOM directory must be in same anatomical plane. If a DICOM directory
+        contians images from different anatomical plane, then it will be converted to 
+        multiple volumes. Only one of these volumes would be registered to fixed image.
+        
+        Output Specifications:
+        * FixedTiled.jpg is tiled representation of the fixed volume.
+        * For each moving image, there are two outputs: <prefix>Warped.nii.gz 
+          and <prefix>WarpedTiled.jpg. Prefix is name of input image stripped of file extension.
+
         Make sure output directory is world writable.
         """
 
-        subprocess.run('antsRegistrationSyN.sh -d 2 -f {}/fixedImage.nii.gz \
-                        -m {}/movingImage.nii.gz -o {}/output' 
-                       .format(options.inputdir,options.inputdir,options.outputdir)
+        if options.fixed == None:
+            self.error("A fixed image is required.")
+            return
+            
+        out_path = options.outputdir
+        in_path = options.inputdir
+        tmp_path = out_path + '/tmp'    # Make tmp folder to hold output of DICOM -> NIFTI conversion
+        try:
+            os.mkdir(tmp_path)
+        except FileExistsError:
+            pass
+
+        # varaibles below store abosolute file paths
+        fixed_image_name = ''           # Filename for fixed image
+        moving_image_list = []          # List of filenames for moving images           
+        
+        if os.path.isfile(in_path+'/'+options.fixed):
+            fixed_image_name = in_path + '/' + options.fixed
+        else:
+            # Fixed image is a directory. Assume to contain .dcm files
+            fixed_image_name = 'fixed_image'
+            subprocess.run('dcm2niix -o {} -f {} {}/{}'
+                           .format(tmp_path,fixed_image_name,in_path,options.fixed).split())
+            fixed_image_name = tmp_path + '/' + 'fixed_image.nii'
+        
+        for name in os.listdir(in_path):
+            if name == options.fixed or name == fixed_image_name: 
+                continue
+            if not os.path.isfile(in_path + '/' + name):
+                # Assume to be directory full of .dcm slices
+                subprocess.run('dcm2niix -o {} -f {} {}/{}'
+                               .format(tmp_path,name,in_path,name).split())
+                # dcm2niix might output multiple nifti files, but we'll assume there is only one
+                moving_image_list.append(tmp_path + '/' + name+'.nii')
+
+            else:
+                filename_split = name.strip().split('.')
+                if len(filename_split) > 1 and filename_split[-1] == 'nii':   # .nii extension
+                    moving_image_list.append(in_path + '/' + name)
+                elif len(filename_split) > 2 and filename_split[-2] == 'nii': # .nii.gz extension
+                    moving_image_list.append(in_path + '/' + name)
+            
+        # Make JPEG image of fixed image
+        subprocess.run('CreateTiledMosaic -i {} -o {}/FixedTiled.nii' 
+                       .format(fixed_image_name, out_path)
                        .split())
+        subprocess.run('ConvertToJpg {}/FixedTiled.nii {}/FixedTiled.jpg' 
+                       .format(out_path, out_path)
+                       .split())
+        os.remove(out_path + '/FixedTiled.nii')
+     
+        # Run ANTS registration on each of the mocing images and create JPEG Tiled image
+        for moving_image_name in moving_image_list:
+            # Change antsRegistrationSyNQuick.sh to antsRegistrationSyN.sh when not testing
+            name_wo_ext = moving_image_name.split('/')[-1].split('.')[0]
+
+            # Ants Registration Call
+            subprocess.run('antsRegistrationSyN.sh -d 3 -f {} \
+                            -m {} -o {}/{}' 
+                           .format(fixed_image_name,
+                                   moving_image_name, out_path,
+                                   name_wo_ext)
+                           .split())
+            # output will be named <name_wo_ext>Warped.nii.gz
+            
+            # Make Tiled Mosaic JPEG
+            subprocess.run('CreateTiledMosaic -i {}/{}Warped.nii.gz -o {}/{}WarpedTiled.nii' 
+                           .format(out_path, name_wo_ext, 
+                                   out_path, name_wo_ext)
+                           .split())
+            subprocess.run('ConvertToJpg {}/{}WarpedTiled.nii {}/{}WarpedTiled.jpg' 
+                           .format(out_path, name_wo_ext,
+                                   out_path, name_wo_ext)
+                           .split())
+            
+            # remove extra outputs
+            files_to_be_removed = [out_path + '/' + name_wo_ext + '1InverseWarp.nii.gz',
+                                   out_path + '/' + name_wo_ext + '1Warp.nii.gz',
+                                   out_path + '/' + name_wo_ext + 'InverseWarped.nii.gz',
+                                   out_path + '/' + name_wo_ext + '0GenericAffine.mat',
+                                   out_path + '/' + name_wo_ext + 'WarpedTiled.nii']
+            for filename in files_to_be_removed:
+                try:
+                    os.remove(filename)
+                except FileNotFoundError:
+                    pass
+        subprocess.run(['rm','-rf',tmp_path])
 
 # ENTRYPOINT
 if __name__ == "__main__":


### PR DESCRIPTION
@rudolphpienaar @danmcp @jbernal0019 

Also added argument for fixed image. One fixed image allowed. All other images assumed as moving images and registered to fixed image. 

Example call:
```
docker run -v $(pwd)/in:/incoming -v $(pwd)/out:/outgoing   \
        fnndsc/pl-antsreg antsreg.py            \
        /incoming /outgoing -f template.nii.gz
```

Pass file name for fixed image using -f argument. If it is a folder of .dcm files, pass directory name. 

DICOM files are converted to NIFTI before inputting to ants.

The image plug-in doesn't work when the DICOM slices are not all in one anatomical plane. In this case, converting the DICOM slices to NIFTI will produce multiple volumes. Currently, the image plug-in chooses one volume at random to register and ignores the other ones. Is this a case that we need to handle?